### PR TITLE
HTTPS support

### DIFF
--- a/src/client/core/SocketClient.js
+++ b/src/client/core/SocketClient.js
@@ -12,7 +12,12 @@ function SocketClient()
 
     var Socket = window.MozWebSocket || window.WebSocket;
 
-    BaseSocketClient.call(this, new Socket('ws://' + document.location.host + document.location.pathname, ['websocket']));
+    var protocol = 'ws://';
+    if(location.protocol === 'https:') {
+        protocol = 'wss://';
+    }
+
+    BaseSocketClient.call(this, new Socket(protocol + document.location.host + document.location.pathname, ['websocket']));
 
     this.socket.addEventListener('open', this.onOpen);
     this.socket.addEventListener('error', this.onError);

--- a/src/client/views/index.html
+++ b/src/client/views/index.html
@@ -12,7 +12,7 @@
         <meta name="keywords" content="Curvytron, Game, Curve, Multiplayer">
         <link rel="author" href="humans.txt" />
         <link rel="icon" type="image/png" href="images/favicon.png" />
-        <link href='http://fonts.googleapis.com/css?family=Lato:300,400,700' rel='stylesheet' type='text/css'>
+        <link href='//fonts.googleapis.com/css?family=Lato:300,400,700' rel='stylesheet' type='text/css'>
         <link rel="stylesheet" href="css/style.css">
         <meta property="og:title" content="Curvytron - A multiplayer tron-like game... with curves!"/>
         <meta property="og:type" content="game"/>


### PR DESCRIPTION
J'étais stupéfait après avoir activé le SSL pour Curvytron dans mon vhost nginx que ça ne marchait pas... du coup je l'ai rendu compatible et j'ai fait en sorte que cela sélectionne bien wss:// si la page est servie en HTTPS ou ws:// si elle est servie en HTTP, pour éviter des problèmes de pare-feu qui pourraient désactiver l'HTTPS.

Et merci pour ce jeu sinon, j'y ai joué pendant des heures et je ne le regrette pas :D