### PR TITLE
Require Node >= 22 (fs.globSync floor)

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -1,6 +1,6 @@
 ## Prerequisite
 
-Curvytron runs on [node.js >= v18](https://nodejs.org/) (the build uses `fs.globSync`, `node --watch-path` and Vite).
+Curvytron runs on [node.js >= v22](https://nodejs.org/) (the build uses `fs.globSync`, `node --watch-path` and Vite).
 You need to install node on the machine that will run the Curvytron server.
 
 ## Installation

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "url": "https://github.com/Elao/curvytron"
   },
   "license": "MIT",
+  "engines": {
+    "node": ">=22"
+  },
   "contributors": [
     {
       "name": "Johan Dufour",


### PR DESCRIPTION
The build scripts use `fs.globSync`, which only exists since Node 22, so the installation doc claiming >= v18 would break the build on Node 18/20. 

Bump the documented version and declare it in package.json engines so npm warns on unsupported runtimes.